### PR TITLE
fix: Update Docker build process to generate commit info on host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,7 @@
 FROM nginx:latest
 
-# Install Node.js for generating commit info
-RUN apt-get update && apt-get install -y nodejs npm git
+# Set working directory for nginx
+WORKDIR /usr/share/nginx/html
 
-# Set working directory
-WORKDIR /app
-
-# Copy package.json and scripts first
-COPY package.json generate-commit-info.js ./
-
-# Generate commit info
-RUN node generate-commit-info.js
-
-# Copy the rest of the application
-COPY . /usr/share/nginx/html/
-
-# Copy generated commit info to the nginx directory
-RUN cp /app/commit-info.json /usr/share/nginx/html/
+# Copy the application files
+COPY . .

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "author": "Rob Brennan <rob@sploosh.ai>",
   "scripts": {
-    "docker:build": "docker compose build",
+    "docker:build": "npm run generate-commit-info && docker compose build",
     "docker:up": "docker compose up -d",
     "docker:down": "docker compose down",
     "docker:restart": "docker compose restart",


### PR DESCRIPTION
# Description

Fixes an issue with the version footer where commit information was showing as "unknown" in the production build. The problem was that the commit info was being generated inside the Docker container during build time, but the .git directory wasn't available in the container.

This PR changes the approach to generate the commit info on the host machine before building the Docker image, ensuring that the version footer displays the correct commit hash, date, and branch information.

## Type of Change

version: fix     # Bug fix (patch version bump)

## Changes

- Simplified the Dockerfile to only copy files, not generate commit info
- Updated package.json scripts to generate commit info before building the Docker image
- Removed Node.js and git installation from the Dockerfile, making builds faster

## Testing

- [x] I have tested these changes locally using Docker Compose
- [x] The version footer now correctly displays commit information
- [x] All existing functionality continues to work
